### PR TITLE
Update an if+else control block to fix an issue #31

### DIFF
--- a/Blocks.js
+++ b/Blocks.js
@@ -522,6 +522,9 @@ define('Blocks', ['Problems', 'BlocklyPython', 'BlocklyMsg', 'Exceptions'], func
                 this.appendStatementInput('ELSE')
                     .appendField(Blockly.Msg.CONTROLS_IF_MSG_ELSE);
                 // this.mutationToDom();
+
+                this.elseCount_ = 1;
+                this.elseifCount_ = 0;
             }
         });
 


### PR DESCRIPTION
According to google/blockly repo
(https://github.com/google/blockly/blob/master/blocks/logic.js)

there are two parameters that are needed for actual configuration of
an if-block. That's why adding elseCount_ and elseifCount_
initialization to init function of if+else block fixes the problem with
disappeared 'else' parts.